### PR TITLE
Fixed inverted odom frame on initialising with an empty ```init_pose_from_topic```

### DIFF
--- a/src/srf_node.cpp
+++ b/src/srf_node.cpp
@@ -72,9 +72,9 @@ CLaserOdometry2D::CLaserOdometry2D()
         initial_robot_pose.pose.pose.position.x = 0;
         initial_robot_pose.pose.pose.position.y = 0;
         initial_robot_pose.pose.pose.position.z = 0;
-        initial_robot_pose.pose.pose.orientation.z = 0;
         initial_robot_pose.pose.pose.orientation.x = 0;
         initial_robot_pose.pose.pose.orientation.y = 0;
+        initial_robot_pose.pose.pose.orientation.z = 0;
         initial_robot_pose.pose.pose.orientation.w = 1;
     }
 

--- a/src/srf_node.cpp
+++ b/src/srf_node.cpp
@@ -72,10 +72,10 @@ CLaserOdometry2D::CLaserOdometry2D()
         initial_robot_pose.pose.pose.position.x = 0;
         initial_robot_pose.pose.pose.position.y = 0;
         initial_robot_pose.pose.pose.position.z = 0;
-        initial_robot_pose.pose.pose.orientation.w = 0;
+        initial_robot_pose.pose.pose.orientation.z = 0;
         initial_robot_pose.pose.pose.orientation.x = 0;
         initial_robot_pose.pose.pose.orientation.y = 0;
-        initial_robot_pose.pose.pose.orientation.z = 1;
+        initial_robot_pose.pose.pose.orientation.w = 1;
     }
 
     //Init variables


### PR DESCRIPTION
The quaternion should be z=0 and w=1